### PR TITLE
support Debounce & Throttle

### DIFF
--- a/Documents/Chinese/BasicOperators.md
+++ b/Documents/Chinese/BasicOperators.md
@@ -610,7 +610,8 @@ dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1.0 * NSEC_PER_SEC), dispatch_ge
 });
 
 /* 打印如下：
-下载进度 0.5
+下载进度 0.4
+下载进度 0.9
 下载进度 1.0
  */
 ```

--- a/Documents/English/BasicOperators.md
+++ b/Documents/English/BasicOperators.md
@@ -567,13 +567,13 @@ Received 2
 
 Throttle describes such an operation: for the upstream value，if there is some values arrived in a `interval` time，just passing the last received value Downstream. Because the transfer is asynchronous, throttle operations typically require a GCD queue to tell EasyReact where to pass.
 
-The general Throttle operation is used to limit times do some action in interval time. such a download task may  callback 10 times per second, report to UI refresh can use throttle 0.5, then the UI refresh just 2 times per second:
+The general throttle operation is used to reduce value sending times between interval second period. Such as a download task may raise 10 values in one second, we could refresh UI only 2 times per second if we use throttle 0.5 like this:
 
 ```objective-c
 EZRMutableNode<NSString *> *inputNode = [EZRMutableNode new];
-EZRNode<NSString *> *viewUpdateNode = [inputNode throttle:0.5 queue:dispatch_get_main_queue()];             // <- 单位是秒
+EZRNode<NSString *> *viewUpdateNode = [inputNode throttle:0.5 queue:dispatch_get_main_queue()];             // <- Unit is second
 [[viewUpdateNode listenedBy:self] withBlock:^(NSString *next) {
-    NSLog(@"下载进度 %@", next);
+    NSLog(@"Download progress %@", next);
 }];
 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.0 * NSEC_PER_SEC), dispatch_get_global_queue(0, 0), ^{
     inputNode.value = @"0";
@@ -609,20 +609,21 @@ dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1.0 * NSEC_PER_SEC), dispatch_ge
     inputNode.value = @"1.0";
 });
 
-/* 打印如下：
-下载进度 0.5
-下载进度 1.0
+/* The result is as follows：
+Download progress 0.4
+Download progress 0.9
+Download progress 1.0
  */
 ```
 
-大家通常都想要在主队列完成监听，所以`throttleOnMainQueue:`方法快速的提供了节流器到主队列的能力：
+We usually want to listen in the main queue, so the `throttleOnMainQueue:` method quickly provides throttled capabilities to the main queue:
 
 ```objective-c
 EZRMutableNode<NSString *> *inputNode = [EZRMutableNode new];
 EZRNode<NSString *> *searchNode = [inputNode throttleOnMainQueue:1];
 ```
 
-等价于
+Equivalent:
 
 ```objective-c
 EZRMutableNode<NSString *> *inputNode = [EZRMutableNode new];
@@ -664,7 +665,7 @@ You want to search for hello world
   */
 ```
 
-We usually want to listen in the main queue, so the `throttleOnMainQueue:` method quickly provides throttled capabilities to the main queue:
+We usually want to listen in the main queue, so the `debounceOnMainQueue:` method quickly provides debounced capabilities to the main queue:
 
 ```objective-c
 EZRMutableNode<NSString *> *inputNode = [EZRMutableNode new];
@@ -675,7 +676,7 @@ Equivalent:
 
 ```objective-c
 EZRMutableNode<NSString *> *inputNode = [EZRMutableNode new];
-EZRNode<NSString *> *searchNode = [inputNode throttle:1 queue:dispatch_get_main_queue()];
+EZRNode<NSString *> *searchNode = [inputNode debounce:1 queue:dispatch_get_main_queue()];
 ```
 
 ### skip

--- a/EasyReact/Classes/Core/EZRNode+Operation.h
+++ b/EasyReact/Classes/Core/EZRNode+Operation.h
@@ -160,9 +160,9 @@ FOUNDATION_EXTERN NSString * const EZRExceptionReason_CasedNodeMustGenerateBySwi
 - (EZRNode *)flatten;
 
 /**
- Changes value if and only if the value does not change again in `interval` seconds.
+ Changes value at most once in `interval` seconds.
  
- @discusstion If a value does not last for `interval` seconds, its listeners / downstreamNodes will not receive this value.
+ @discusstion If change value many times in `interval` seconds, its listeners / downstreamNodes will just receive the last value.
  An throttled empty value will not notify its listeners or downdstreams no matter how long it remains empty.
  The listener or downstream blocks will always be invoked in the main queue.
  If you want to dispatch those blocks to a specified queue, use `-throttle:queue:` method.
@@ -175,9 +175,9 @@ FOUNDATION_EXTERN NSString * const EZRExceptionReason_CasedNodeMustGenerateBySwi
 - (EZRNode<T> *)throttleOnMainQueue:(NSTimeInterval)timeInterval;
 
 /**
- Changes value if and only if the value does not change again in `interval` seconds.
+ Changes value at most once in `interval` seconds.
  
- @discusstion If a value does not last for `interval` seconds, its listeners / downstreamNodes will not receive this value.
+ @discusstion If change value many times in `interval` seconds, its listeners / downstreamNodes will just receive the last value.
  An throttled empty value will not notify its listeners or downdstreams no matter how long it remains empty.
  
  @note It is NOT a real time mechanism, just like an NSTimer.
@@ -187,6 +187,35 @@ FOUNDATION_EXTERN NSString * const EZRExceptionReason_CasedNodeMustGenerateBySwi
  @return                A new EZRNode which change its value if and only if the value lasts for a given interval.
  */
 - (EZRNode<T> *)throttle:(NSTimeInterval)timeInterval queue:(dispatch_queue_t)queue;
+
+/**
+ Changes value if and only if the value does not change again in future `interval` seconds.
+ 
+ @discusstion If a value next change in future `interval` seconds, its listeners / downstreamNodes will not receive this value.
+ An debounced empty value will not notify its listeners or downdstreams no matter how long it remains empty.
+ The listener or downstream blocks will always be invoked in the main queue.
+ If you want to dispatch those blocks to a specified queue, use `-debounce:queue:` method.
+ 
+ @note It is NOT a real time mechanism, just like an NSTimer.
+ 
+ @param timeInterval    The time interval in seconds, MUST be greater than 0.
+ @return                A new EZRNode which change its value if the value does not change again in future `interval` seconds.
+ */
+- (EZRNode<T> *)debounceOnMainQueue:(NSTimeInterval)timeInterval;
+
+/**
+ Changes value if and only if the value does not change again in future `interval` seconds.
+ 
+ @discusstion If a value next change in future `interval` seconds, its listeners / downstreamNodes will not receive this value.
+ An debounced empty value will not notify its listeners or downdstreams no matter how long it remains empty.
+ 
+ @note It is NOT a real time mechanism, just like an NSTimer.
+ 
+ @param timeInterval    The time interval in seconds, MUST be greater than 0.
+ @param queue           The queue which listener block will be invoked in.
+ @return                A new EZRNode which change its value if the value does not change again in future `interval` seconds.
+ */
+- (EZRNode<T> *)debounce:(NSTimeInterval)timeInterval queue:(dispatch_queue_t)queue;
 
 /**
  Delays the passing value from the receiver in specific queue. Delay operation will return a new node as the receiver's downstream.

--- a/EasyReact/Classes/Core/EZRNode+Operation.m
+++ b/EasyReact/Classes/Core/EZRNode+Operation.m
@@ -21,6 +21,7 @@
 #import "EZRDistinctTransform.h"
 #import "EZRFlattenTransform.h"
 #import "EZRThrottleTransform.h"
+#import "EZRDebounceTransform.h"
 #import "EZRBlockCancelable.h"
 #import "EZRZipTransform.h"
 #import "EZRZipTransformGroup.h"
@@ -146,6 +147,19 @@ NSString * const EZRExceptionReason_CasedNodeMustGenerateBySwitchOrSwitchMapOper
     NSParameterAssert(queue);
     EZRNode *returnedNode = EZRNode.new;
     EZRThrottleTransform *transform = [[EZRThrottleTransform alloc] initWithThrottle:timeInterval on:queue];
+    [returnedNode linkTo:self transform:transform];
+    return returnedNode;
+}
+
+- (EZRNode *)debounceOnMainQueue:(NSTimeInterval)timeInterval {
+    return [self debounce:timeInterval queue:dispatch_get_main_queue()];
+}
+
+- (EZRNode *)debounce:(NSTimeInterval)timeInterval queue:(dispatch_queue_t)queue {
+    NSParameterAssert(timeInterval > 0);
+    NSParameterAssert(queue);
+    EZRNode *returnedNode = EZRNode.new;
+    EZRDebounceTransform *transform = [[EZRDebounceTransform alloc] initWithDebounce:timeInterval on:queue];
     [returnedNode linkTo:self transform:transform];
     return returnedNode;
 }

--- a/EasyReact/Classes/Core/NodeTransforms/EZRDebounceTransform.h
+++ b/EasyReact/Classes/Core/NodeTransforms/EZRDebounceTransform.h
@@ -1,0 +1,30 @@
+/**
+ * Beijing Sankuai Online Technology Co.,Ltd (Meituan)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#import <EasyReact/EZRTransform.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EZRDebounceTransform : EZRTransform
+
+- (instancetype)initWithDebounce:(NSTimeInterval)timeInterval on:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/EasyReact/Classes/Core/NodeTransforms/EZRDebounceTransform.m
+++ b/EasyReact/Classes/Core/NodeTransforms/EZRDebounceTransform.m
@@ -1,0 +1,72 @@
+/**
+ * Beijing Sankuai Online Technology Co.,Ltd (Meituan)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#import "EZRDebounceTransform.h"
+#import "EZRNode+ProjectPrivate.h"
+#import "EZRMetaMacros.h"
+#import "EZRMetaMacrosPrivate.h"
+
+@implementation EZRDebounceTransform {
+    NSTimeInterval _debounceInterval;
+    dispatch_source_t _debounceSource;
+    dispatch_queue_t _queue;
+    EZR_LOCK_DEF(_sourceLock);
+}
+
+- (instancetype)initWithDebounce:(NSTimeInterval)timeInterval on:(dispatch_queue_t)queue {
+    NSParameterAssert(timeInterval > 0);
+    NSParameterAssert(queue);
+    if (self = [super init]) {
+        _debounceInterval = timeInterval;
+        _queue = queue;
+        EZR_LOCK_INIT(_sourceLock);
+        [super setName:@"Debounce"];
+    }
+    return self;
+}
+
+- (void)next:(id)value from:(EZRSenderList *)senderList context:(nullable id)context {
+    EZR_SCOPELOCK(_sourceLock);
+    
+    if (_debounceSource) {
+        dispatch_source_cancel(_debounceSource);
+        _debounceSource = nil;
+    }
+    
+    _debounceSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _queue);
+    dispatch_source_set_timer(_debounceSource, dispatch_time(DISPATCH_TIME_NOW, _debounceInterval * NSEC_PER_SEC), DISPATCH_TIME_FOREVER, 0.005);
+    
+    @ezr_weakify(self)
+    dispatch_source_set_event_handler(_debounceSource, ^{
+        @ezr_strongify(self)
+        if (!self) {
+            return ;
+        }
+        EZR_SCOPELOCK(self->_sourceLock);
+        [self _superNext:value from:senderList context:context];
+        
+        dispatch_source_cancel(self->_debounceSource);
+        self->_debounceSource = nil;
+    });
+    
+    dispatch_resume(_debounceSource);
+}
+
+- (void)_superNext:(id)value from:(EZRSenderList *)senderList context:(nullable id)context {
+    [super next:value from:senderList context:context];
+}
+
+@end

--- a/EasyReact/Classes/EasyReact.h
+++ b/EasyReact/Classes/EasyReact.h
@@ -57,6 +57,7 @@ FOUNDATION_EXPORT const unsigned char EasyReactVersionString[];
 #import <EasyReact/EZRFlattenTransform.h>
 #import <EasyReact/EZRMapTransform.h>
 #import <EasyReact/EZRThrottleTransform.h>
+#import <EasyReact/EZRDebounceTransform.h>
 #import <EasyReact/EZRZipTransform.h>
 #import <EasyReact/EZRZipTransformGroup.h>
 #import <EasyReact/EZRSwitchMapTransform.h>

--- a/Example/Tests/EZRNode+OperationSpec.m
+++ b/Example/Tests/EZRNode+OperationSpec.m
@@ -1338,10 +1338,13 @@ describe(@"EZRNode", ^{
                 });
             });
             
-            // throttle interval time [0.12 - 0.22] r re 【res】
-            // throttle interval time [0.25 - 0.35] 【resu】
-            // throttle interval time [1.20 - 1.32] resul 【result】
-            expect(throttledValue).to(receive(@[@"res", @"resu", @"result"]));
+            // throttle interval time [0.12 - 0.22) r re res ->【res】
+            // throttle interval time [0.22 - 0.32) resu ->【resu】
+            // throttle interval time [0.32 - 0.42) ->【】
+            // ......
+            // throttle interval time [1.12 - 1.22) resul ->【resul】
+            // throttle interval time [1.22 - 1.32) result ->【result】
+            expect(throttledValue).to(receive(@[@"res", @"resu", @"resul", @"result"]));
         });
     
         it(@"throttle should ignores empty values", ^{


### PR DESCRIPTION
### 支持防抖和节流

EasyReact当前版本的“节流”实际上是实现了“防抖”的效果，通常用于处理高频率UI事件触发带来的问题。而另一种节流方式则是对于单位时间内的流量控制，这也是我之前开发中遇到过的场景，所以结合网络上对防抖和节流的定义和理解，我重新实现了变换类EZRThrottleTransform, 并将原本EZRThrottleTransform的实现(防抖实现)迁移到新定义的变换类EZRDebounceTransform中。单元测试用例和说明文档也已经补充和修正。

### 另外的说明

1. 由于EZRThrottleTransform的内部实现发生了变更，所以可能会对已经使用该变换的代码逻辑产生影响，但鉴于这两种的具体实现，我认为不会造成意外的缺陷；
2. 中英文说明文档页已经补充，如果接受本次的合并请求，希望对我编写的英文说明进行必要的修正；

